### PR TITLE
Fix Database now clears the Team Strip Edited Flag and clears Team St…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5113,6 +5113,11 @@ void fix_database()
 	}
 	if(gn_listsel > -1)
 		show_player_info(gn_playind[gn_listsel]);
+
+	for (ii = 0; ii < gnum_teams; ii++)
+	{
+		gteams[ii].b_changed = true;
+	}
 }
 
 

--- a/pes17.cpp
+++ b/pes17.cpp
@@ -671,7 +671,54 @@ void extract_team_info17(team_entry team, int &current_byte, void* ghdescriptor)
 	current_byte+=0x2; //19:0
 	write_dataOld(team.b_edit_name, 4, 1, current_byte, pDescriptorOld);
 
-	current_byte+=0x7F;
+	current_byte++; //1A
+	write_dataOld(0, 5, 1, current_byte, pDescriptorOld); //1A:5 (Team Strip Edited Flag)
+
+	current_byte++; //1B
+	current_byte++; //1C
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 1
+	current_byte++;
+	current_byte++;
+	current_byte++;
+	write_dataOld(0x1, 0, 8, current_byte, pDescriptorOld); //Team Strip 2
+	current_byte++;
+	current_byte++;
+	current_byte++;
+	write_dataOld(0x80, 0, 8, current_byte, pDescriptorOld); //Team Strip 3 (GK)
+	current_byte++;
+	current_byte++;
+	current_byte++;
+
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 4
+	write_dataOld(0xC0, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 5
+	write_dataOld(0xC0, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 6
+	write_dataOld(0xC0, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 7
+	write_dataOld(0xC0, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 8
+	write_dataOld(0xC0, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 9
+	write_dataOld(0xC0, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0x0, 0, 8, current_byte, pDescriptorOld); //Team Strip 10
+	write_dataOld(0xC0, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+	write_dataOld(0xFF, 0, 8, current_byte, pDescriptorOld);
+
+	current_byte += 0x54;
 	
 	WideCharToMultiByte(CP_UTF8, 0, team.name, -1, (LPSTR)&(pDescriptorOld->data[current_byte]), 0x46, NULL, NULL);
 	current_byte+=0x46;


### PR DESCRIPTION
During VGL we encountered a problem where teams had too many or too few kits. After doing some research we found that this is because kit slots are assigned in the save file.

This commit resets these slots and the Team Strip Edited flag to the default values on all teams when the user hits Fix Database. I have yet to find a downside to having these values reset so because I wanted to get this fix out asap I thought it would be fine to just fix every team in the whole save.

For the upcoming Autumn season, if no team changed the amount of kits since the last time this save was based on then there is no need to implement this change hastily. However, if teams are reporting they have the wrong amount of kits in-game while there is no issue with their aesthetics export, then I recommend to use this change to fix that.