### PR TITLE
Fix playstyle listing in TSV export

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4720,7 +4720,7 @@ void roster_data_output()
 						  _T("The Destroyer"),
 						  _T("Extra Frontman"),
 						  _T("Offensive Fullback"),
-						  _T("Defensive Fullback")
+						  _T("Defensive Fullback"),
 						  _T("Target Man"),
 						  _T("Creative Playmaker"),
 						  _T("Build Up"),


### PR DESCRIPTION
If you use the "Output rosters to TSV" function, the missing comma means players with defensive FB will be listed as "Defensive FullbackTarget Man" and all playstyles that comes after that will be off by one (off. GK listed as def. GK, def. GK listed as None, etc.).